### PR TITLE
Install plugin in INSTALL_PLUGINSDIR/sensors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,5 +34,5 @@ target_link_libraries(qtsensors_sensorfw PUBLIC
 )
 
 install(TARGETS qtsensors_sensorfw
-        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}/qt6/plugins/sensors/)
+        LIBRARY DESTINATION ${INSTALL_PLUGINSDIR}/sensors/)
 install(FILES Sensors.conf DESTINATION /etc/xdg/QtProject/)


### PR DESCRIPTION
This is an attempt to fix the issue that the plugin isn't installed in the correct folder (i.e. /usr/lib/plugins/sensors) on LuneOS.
Using INSTALL_PLUGINSDIR solves the issue on LuneOS, however this variable might be introduced by meta-qt6.

@erikinkinen is this variable available on your side?